### PR TITLE
Feature/add lazy loaded spines

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -38,6 +38,7 @@
     Title as AppBarTitle,
   } from "@smui/top-app-bar/styled";
   import Select, { Option } from '@smui/select/styled';
+  import LazyImageLoader from "./lib/components/LazyImageLoader.svelte";
 
   let regions = [
     {
@@ -574,8 +575,8 @@
                 : "width: 400px; height: 24px;"}
               class="zoom"
             >
-              <Image
-              src="{base_url}/_resized/{game[1]}/spine.png"
+              <LazyImageLoader
+                src="{base_url}/_resized/{game[1]}/spine.png"
                 alt={game[0]}
                 style={switchSpineView
                   ? "height: 100%;"

--- a/src/lib/components/IntersectionObserver.svelte
+++ b/src/lib/components/IntersectionObserver.svelte
@@ -1,0 +1,37 @@
+<script>
+	import { onMount } from 'svelte';
+	export let once = false;
+	export let top = 0;
+	export let bottom = 0;
+	export let left = 0;
+	export let right = 0;
+  let intersecting = false;
+  
+	let container;
+	onMount(() => {
+		if (typeof IntersectionObserver !== 'undefined') {
+			const rootMargin = `${bottom}px ${left}px ${top}px ${right}px`;
+			const observer = new IntersectionObserver(entries => {
+				intersecting = entries[0].isIntersecting;
+				if (intersecting && once) {
+					observer.unobserve(container);
+				}
+			}, {
+				rootMargin
+			});
+			observer.observe(container);
+			return () => observer.unobserve(container);
+		}
+	});
+</script>
+
+<style>
+	div {
+		width: 100%;
+		height: 100%;
+	}
+</style>
+
+<div bind:this={container}>
+	<slot {intersecting}></slot>
+</div>

--- a/src/lib/components/LazyImage.svelte
+++ b/src/lib/components/LazyImage.svelte
@@ -1,0 +1,23 @@
+<script>
+  import {
+    Image,
+  } from "@smui/image-list/styled";
+
+  export let src;
+  export let alt;
+  export let style;
+
+</script>
+
+<style>
+  img {
+    height: 200px;
+    opacity: 0;
+    transition: opacity 1200ms ease-out;
+  }
+  img.loaded {
+    opacity: 1;
+  }
+</style>
+
+<Image {src} {alt} {style} loading="lazy" on:click />

--- a/src/lib/components/LazyImageLoader.svelte
+++ b/src/lib/components/LazyImageLoader.svelte
@@ -1,0 +1,16 @@
+<script>
+  export let src;
+  export let alt;
+  export let style;
+  
+  import IntersectionObserver from './IntersectionObserver.svelte'
+  import LazyImage from './LazyImage.svelte'
+
+  let nativeLoading = false  
+</script>
+
+<IntersectionObserver once={true} let:intersecting={intersecting}>
+  {#if intersecting || nativeLoading}
+    <LazyImage {alt} {src} {style} on:click />
+  {/if}
+</IntersectionObserver> 


### PR DESCRIPTION
Credit to [Lazy Loading Images in Svelte](https://css-tricks.com/lazy-loading-images-in-svelte/) for the observer idea, which is loosely based on the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).

One issue that I noticed is that there's a need to re-fetch images when travelling back to the "Cabinet" page; however, this problem is reduced in severity with the Lazy Loading change (i.e.: few MB of re-fetching, rather than up to hundreds of MB).